### PR TITLE
VARIANT_BOOL is no longer exported from comtypes.

### DIFF
--- a/pyMSVC/vswhere.py
+++ b/pyMSVC/vswhere.py
@@ -56,11 +56,11 @@ from comtypes import (
 )
 from comtypes._safearray import (  # NOQA
     SAFEARRAY,
-    VARIANT_BOOL,
     SafeArrayLock as _SafeArrayLock,
     SafeArrayUnlock as _SafeArrayUnlock
 )
 
+VARIANT_BOOL = ctypes.c_short
 LPVARIANT = POINTER(tagVARIANT)
 VARIANT = tagVARIANT
 ENUM = ctypes.c_uint


### PR DESCRIPTION
I have the following composition:
* comtypes: 1.4.13
* pyMSVC: 0.6.1
* Python: 3.11.5

When importing pyMSVC, I have an error in the vswhere module:
```
ImportError: cannot import name 'VARIANT_BOOL' from 'comtypes._safearray'
```
Looks like comtypes stopped exporting this type.